### PR TITLE
Complete translation of Chinese comments and documentation to English

### DIFF
--- a/09.Cases/maf_harness_managed_agent/maf_harness/harness/harness.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/harness/harness.py
@@ -1,22 +1,22 @@
 """
 maf_harness.harness.harness
 ============================
-编排器是"大脑" — 一个无状态的编排循环，由
-Microsoft Foundry（FoundryChatClient）驱动。它具有以下特性：
+The harness is the "brain" — a stateless orchestration loop,
+driven by Microsoft Foundry (FoundryChatClient). It has the following characteristics:
 
-  1. 无状态    ：所有状态都保存在会话日志中，而非编排器内。
-  2. 解耦      ：仅通过 execute(name, input) → string 调用沙箱。
-  3. 可恢复    ：wake(session_id) 从持久化日志中重新注入上下文。
-  4. Foundry   ：唯一的 LLM 后端是 FoundryChatClient — 无 OpenAI SDK。
+  1. Stateless   : All state is stored in the session log, not in the harness.
+  2. Decoupled   : Calls sandboxes only via execute(name, input) → string.
+  3. Recoverable : wake(session_id) rehydrates context from durable log.
+  4. Foundry     : The only LLM backend is FoundryChatClient — zero OpenAI SDK.
 
-必需的环境变量：
+Required environment variables:
     FOUNDRY_PROJECT_ENDPOINT   https://<hub>.services.ai.azure.com
-    FOUNDRY_MODEL              gpt-5.4（任何 Foundry 已部署的模型）
+    FOUNDRY_MODEL              gpt-5.4 (any Foundry deployed model)
 
-认证（DefaultAzureCredential 优先级顺序）：
-    1. FOUNDRY_API_KEY 环境变量  → AzureKeyCredential（开发 / CI）
-    2. az login                  → AzureCliCredential（本地开发）
-    3. Managed Identity          → 在 Azure 上自动生效（生产环境）
+Authentication (DefaultAzureCredential precedence):
+    1. FOUNDRY_API_KEY env var  → AzureKeyCredential (dev / CI)
+    2. az login                 → AzureCliCredential (local dev)
+    3. Managed Identity         → automatic on Azure (production)
 """
 
 from __future__ import annotations
@@ -48,15 +48,15 @@ from maf_harness.session.session_log import EventKind, SessionEvent, SessionLog
 from maf_harness.skills.skills import build_skills_provider
 
 
-# ── Foundry 客户端工厂 ────────────────────────────────────────────────────────
+# ── Foundry Client Factory ──────────────────────────────────────────────────
 
 def make_foundry_client(model: str | None = None) -> FoundryChatClient:
     """
-    构建 FoundryChatClient。
+    Build FoundryChatClient.
 
-    认证优先级：
-      1. FOUNDRY_API_KEY 环境变量  → AzureKeyCredential（开发 / CI）
-      2. DefaultAzureCredential    → az login / Managed Identity（生产环境）
+    Authentication priority:
+      1. FOUNDRY_API_KEY env var  → AzureKeyCredential (dev / CI)
+      2. DefaultAzureCredential   → az login / Managed Identity (production)
 
     通过环境变量配置（如未显式传递）：
       FOUNDRY_PROJECT_ENDPOINT

--- a/09.Cases/maf_harness_managed_agent/maf_harness/harness/harness.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/harness/harness.py
@@ -80,15 +80,15 @@ def make_foundry_client(model: str | None = None) -> FoundryChatClient:
     )
 
 
-# ── 编排器配置 ─────────────────────────────────────────────────────────────
+# ── Harness Configuration ───────────────────────────────────────────────────────
 
 @dataclass
 class HarnessConfig:
-    """每个编排器的配置。"""
+    """Configuration per harness."""
     agent_name:          str       = "ManagedAgent"
-    model:               str       = ""          # 回退到 FOUNDRY_MODEL 环境变量
+    model:               str       = ""          # Falls back to FOUNDRY_MODEL env var
     max_iterations:      int       = 20
-    context_window_size: int       = 30          # wake() 时重新加载的事件数
+    context_window_size: int       = 30          # Events reloaded on wake()
     skill_names:         list[str] = field(default_factory=lambda: [
                                         "research", "code_execution",
                                         "summarise", "orchestration",
@@ -149,57 +149,57 @@ def build_sandbox_tools(
                     return f"[SANDBOX FAILED after retry] {exc}"
         return "[SANDBOX FAILED]"
 
-    # ── 带类型的 AF 工具函数 ───────────────────────────────────────────────
+    # ── Typed AF Tool Functions ───────────────────────────────────────────────
 
     async def run_python(
-        code: Annotated[str, Field(description="在隔离沙箱中执行的 Python 代码。")],
+        code: Annotated[str, Field(description="Python code to execute in isolated sandbox.")],
     ) -> str:
-        """在沙箱中执行 Python 代码并返回标准输出。"""
+        """Execute Python code in sandbox and return stdout."""
         return await _exec("run_python", code)
 
     async def web_search(
-        query: Annotated[str, Field(description="要在网上搜索的查询内容。")],
+        query: Annotated[str, Field(description="Query to search on the web.")],
     ) -> str:
-        """搜索网络并返回摘要结果。"""
+        """Search the web and return summarized results."""
         return await _exec("web_search", query)
 
     async def write_file(
-        path:    Annotated[str, Field(description="目标文件路径。")],
-        content: Annotated[str, Field(description="要写入的内容。")],
+        path:    Annotated[str, Field(description="Target file path.")],
+        content: Annotated[str, Field(description="Content to write.")],
     ) -> str:
-        """将内容写入沙箱文件系统中的文件。"""
+        """Write content to a file in sandbox filesystem."""
         return await _exec("write_file", f"{path}::{content}")
 
     async def read_file(
-        path: Annotated[str, Field(description="要读取的文件路径。")],
+        path: Annotated[str, Field(description="File path to read.")],
     ) -> str:
-        """从沙箱文件系统中读取文件。"""
+        """Read a file from sandbox filesystem."""
         return await _exec("read_file", path)
 
     async def get_session_context(
-        last_n: Annotated[int, Field(description="要检索的最近事件数量。")] = 10,
+        last_n: Annotated[int, Field(description="Number of recent events to retrieve.")] = 10,
     ) -> str:
-        """从会话日志中检索最近事件作为上下文。"""
+        """Retrieve recent events from session log for context."""
         events = await session_log.get_context_window(session_id, last_n=last_n)
         return "\n".join(f"[{e.kind.value}] {e.payload}" for e in events) or "(no events)"
 
     return [run_python, web_search, write_file, read_file, get_session_context]
 
 
-# ── 代理编排器 — 大脑 ─────────────────────────────────────────────────────
+# ── Agent Harness — Brain ─────────────────────────────────────────────────────
 
 class AgentHarness:
     """
-    由 Microsoft Foundry 驱动的无状态编排器。
+    Stateless harness driven by Microsoft Foundry.
 
-    生命周期：
-        harness = AgentHarness(session_log, sandbox_mgr, config)
-        await harness.start(session_id)        # 若会话已存在则执行 wake()
-        response = await harness.run(message)  # 一次代理循环轮次
+    Lifecycle:
+        harness = AgentHarness(...)
+        await harness.start(session_id)        # wake() if session exists
+        response = await harness.run(message)  # one agent loop turn
         await harness.shutdown()
 
-    崩溃时：创建新的编排器，调用 start(同一个 session_id)。
-    wake() 会重新注入完整的事件历史 — 无数据丢失。
+    On crash: create a new harness, call start(same session_id).
+    wake() rehydrates full event history — zero data loss.
     """
 
     def __init__(
@@ -212,17 +212,17 @@ class AgentHarness:
         self.session_log = session_log
         self.sandbox_mgr = sandbox_mgr
         self.config      = config or HarnessConfig()
-        self._client     = client   # 注入预构建的客户端（测试 / 复用）
+        self._client     = client   # Inject pre-built client (testing / reuse)
         self._agent:           Agent | None                 = None
         self._session_id:      str | None                   = None
         self._history_provider: InMemoryHistoryProvider | None = None
 
-    # ── 启动 / 唤醒 ──────────────────────────────────────────────────────────
+    # ── Start / Wake ──────────────────────────────────────────────────────────────
 
     async def start(self, session_id: str) -> None:
         """
-        附加到一个会话。如果会话已有事件，则执行
-        wake() — 编排器从持久化日志中重建上下文，不丢失任何历史记录。
+        Attach to a session. If session has existing events, perform
+        wake() — harness rebuilds context from durable log without losing any history.
         """
         self._session_id = session_id
 
@@ -315,7 +315,7 @@ class AgentHarness:
                 yield chunk.text
 
     async def shutdown(self) -> None:
-        """向持久化日志发出 SESSION_END 事件。"""
+        """Emit SESSION_END event to durable log."""
         if self._session_id:
             await self.session_log.emit_event(
                 self._session_id,

--- a/09.Cases/maf_harness_managed_agent/maf_harness/harness/harness.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/harness/harness.py
@@ -58,7 +58,7 @@ def make_foundry_client(model: str | None = None) -> FoundryChatClient:
       1. FOUNDRY_API_KEY env var  → AzureKeyCredential (dev / CI)
       2. DefaultAzureCredential   → az login / Managed Identity (production)
 
-    通过环境变量配置（如未显式传递）：
+    Configured via environment variables (if not explicitly passed):
       FOUNDRY_PROJECT_ENDPOINT
       FOUNDRY_MODEL
     """
@@ -278,10 +278,10 @@ class AgentHarness:
             base += f"\n\nMost recent session events:\n{summary}\n"
         return base
 
-    # ── 运行 ───────────────────────────────────────────────────────────────
+    # ── Execution ───────────────────────────────────────────────────────────────
 
     async def run(self, user_input: str) -> str:
-        """通过 Foundry 执行一次代理循环轮次。"""
+        """Execute one agent loop iteration via Foundry."""
         if self._agent is None or self._session_id is None:
             raise RuntimeError("Harness not started. Call start(session_id) first.")
         try:
@@ -307,7 +307,7 @@ class AgentHarness:
             raise
 
     async def run_streaming(self, user_input: str):
-        """逐步返回从 Foundry 到达的响应文本块。"""
+        """Yield response text chunks as they arrive from Foundry."""
         if self._agent is None:
             raise RuntimeError("Harness not started.")
         async for chunk in self._agent.run(user_input, stream=True):

--- a/09.Cases/maf_harness_managed_agent/maf_harness/harness/harness.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/harness/harness.py
@@ -97,7 +97,7 @@ class HarnessConfig:
     sandbox_timeout_sec: int       = 30
 
 
-# ── 沙箱工具包装器 ─────────────────────────────────────────────────────────
+# ── Sandbox Tool Wrappers ───────────────────────────────────────────────────────
 
 def build_sandbox_tools(
     sandbox_mgr: SandboxManager,
@@ -105,9 +105,9 @@ def build_sandbox_tools(
     session_id:  str,
 ) -> list[Callable]:
     """
-    将 sandbox.execute(name, input) 包装为带类型的 AF 工具函数。
-    沙箱在首次工具调用时延迟创建 — 仅需推理的会话
-    永远不会承担创建开销（TTFT 优化）。
+    Wraps sandbox.execute(name, input) as typed AF tool functions.
+    Sandboxes are lazily created on first tool call — reasoning-only sessions
+    never incur creation overhead (TTFT optimization).
     """
     _state: dict[str, str | None] = {"sandbox_id": None}
 

--- a/09.Cases/maf_harness_managed_agent/maf_harness/hosting/azure_function_host.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/hosting/azure_function_host.py
@@ -1,18 +1,18 @@
 """
 maf_harness.hosting.azure_function_host
 ========================================
-将托管代理编排器托管为 Azure Functions HTTP 触发器。
-LLM 后端：Microsoft Foundry（FoundryChatClient）— 无 OpenAI 依赖。
+Host managed agent harness as Azure Functions HTTP triggers.
+LLM backend: Microsoft Foundry (FoundryChatClient) — zero OpenAI dependency.
 
-端点：
-    POST /sessions                   → 创建会话，返回 session_id
-    POST /sessions/{id}/run          → 执行一次代理轮次
-    GET  /sessions/{id}/events       → 查询会话事件日志
-    POST /sessions/{id}/wake         → 从会话日志中重新注入编排器
-    GET  /health                     → 端点与模型健康检查
+Endpoints:
+    POST /sessions                   → create session, return session_id
+    POST /sessions/{id}/run          → execute one agent turn
+    GET  /sessions/{id}/events       → query session event log
+    POST /sessions/{id}/wake         → rehydrate harness from session log
+    GET  /health                     → endpoint & model health check
 
-任何 Azure Functions 实例都可以服务任何会话 — 路由完全基于
-session_id。无需粘性会话。通过增加实例即可水平扩展。
+Any Azure Functions instance can serve any session — routing purely by
+session_id. No sticky sessions needed. Horizontally scale by adding instances.
 
 local.settings.json:
     {
@@ -24,7 +24,7 @@ local.settings.json:
       }
     }
 
-本地开发（FastAPI）：
+Local development (FastAPI):
     uvicorn maf_harness.hosting.azure_function_host:local_app --reload
 """
 
@@ -47,7 +47,7 @@ from maf_harness.sandbox.sandbox import SandboxManager, VaultStore
 from maf_harness.session.session_log import SessionLog
 
 
-# ── 单例基础设施（每个冷启动容器）───────────────────────────────────────────
+# ── Singleton Infrastructure (per cold-start container) ───────────────────────────
 
 _vault       = VaultStore()
 _session_log = SessionLog()
@@ -59,8 +59,8 @@ _config = HarnessConfig(
     max_iterations=int(os.getenv("MAX_ITERATIONS", "20")),
 )
 
-# 延迟构建，首次请求时创建 — 避免环境变量尚未注入时的冷启动失败
-# （如测试环境中模块导入阶段）。
+# Lazy build on first request — avoid cold-start failure when env vars not yet injected
+# (e.g., during module import in test environments).
 _foundry_client = None
 
 
@@ -85,7 +85,7 @@ async def _handle_run_turn(session_id: str, body: dict) -> dict:
     if not user_input:
         return {"error": "Missing 'input' field."}
 
-    # 每次请求创建新的无状态编排器 — 从持久化会话日志中唤醒
+    # Create a new stateless harness per request — wakes from durable session log
     harness = AgentHarness(
         session_log=_session_log,
         sandbox_mgr=_sandbox_mgr,
@@ -171,16 +171,16 @@ if _AZURE:
         )
 
 
-# ── 本地 FastAPI 开发服务器 ──────────────────────────────────────────────────
+# ── Local FastAPI Development Server ──────────────────────────────────────────────
 
 def create_local_app():
     """
-    镜像 Azure Functions 路由，用于本地开发。
+    Mirror Azure Functions routes for local development.
 
-    用法：
+    Usage:
         uvicorn maf_harness.hosting.azure_function_host:local_app --reload
 
-    环境变量：
+    Environment variables:
         export FOUNDRY_PROJECT_ENDPOINT=https://...
         export FOUNDRY_MODEL=gpt-5.4
         az login

--- a/09.Cases/maf_harness_managed_agent/maf_harness/hosting/azure_function_host.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/hosting/azure_function_host.py
@@ -71,7 +71,7 @@ def _get_client():
     return _foundry_client
 
 
-# ── 处理逻辑（Azure Functions 和 FastAPI 共用）────────────────────────────
+# ── Handler Logic (shared by Azure Functions and FastAPI) ────────────────────────────
 
 async def _handle_create_session(body: dict) -> dict:
     task       = body.get("task", "")
@@ -126,7 +126,7 @@ async def _handle_wake(session_id: str) -> dict:
     }
 
 
-# ── Azure Functions HTTP 触发器 ─────────────────────────────────────────────
+# ── Azure Functions HTTP Triggers ─────────────────────────────────────────────
 
 if _AZURE:
     app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)

--- a/09.Cases/maf_harness_managed_agent/maf_harness/middleware/middleware.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/middleware/middleware.py
@@ -155,9 +155,9 @@ GLOBAL_METRICS = Metrics()
 
 def make_observability_middleware(metrics: Metrics | None = None):
     """
-    测量每次代理运行的首 token 延迟（TTFT）。
-    Anthropic 通过将大脑与沙箱解耦，使 p50 TTFT 减少约 60%，p95 减少超过 90%。
-    此中间件为您的部署跟踪该数值。
+    Measure time-to-first-token (TTFT) latency on every agent run.
+    Anthropic reduced p50 TTFT by ~60% and p95 by >90% by decoupling brain from sandbox.
+    This middleware tracks that metric for your deployment.
     """
     m = metrics or GLOBAL_METRICS
 

--- a/09.Cases/maf_harness_managed_agent/maf_harness/middleware/middleware.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/middleware/middleware.py
@@ -1,14 +1,14 @@
 """
 maf_harness.middleware.middleware
 ==================================
-AF @agent_middleware 中间件栈 — 拦截每次代理轮次的横切关注点，
-不修改代理逻辑。
+AF @agent_middleware middleware stack — intercepts cross-cutting concerns on every agent turn,
+without modifying agent logic.
 
-中间件栈（按顺序应用）：
-    1. SessionLoggingMiddleware  — 将每次轮次写入持久化会话日志
-    2. SecurityMiddleware        — 从上下文中清除凭据模式
-    3. RateLimitMiddleware       — 令牌桶限流器（RPM）
-    4. ObservabilityMiddleware   — TTFT 延迟 + 运行指标
+Middleware stack (applied in order):
+    1. SessionLoggingMiddleware  — write every turn to durable session log
+    2. SecurityMiddleware        — scrub credential patterns from context
+    3. RateLimitMiddleware       — token bucket rate limiter (RPM)
+    4. ObservabilityMiddleware   — TTFT latency + run metrics
 
 AF API: @agent_middleware, AgentContext
 """
@@ -24,10 +24,10 @@ if TYPE_CHECKING:
     from maf_harness.session.session_log import EventKind, SessionEvent, SessionLog
 
 
-# ── 1. 会话日志记录 ────────────────────────────────────────────────────────
+# ── 1. Session Logging ──────────────────────────────────────────────────────────
 
 def make_session_logging_middleware(session_log, session_id: str):
-    """将每次代理轮次作为结构化事件写入持久化会话日志。"""
+    """Write every agent turn as structured events to durable session log."""
 
     @agent_middleware
     async def _mw(ctx: AgentContext, next):
@@ -63,12 +63,12 @@ def make_session_logging_middleware(session_log, session_id: str):
     return _mw
 
 
-# ── 2. 安全 ───────────────────────────────────────────────────────────────
+# ── 2. Security ─────────────────────────────────────────────────────────────────
 
 def make_security_middleware(blocked_patterns: list[str] | None = None):
     """
-    强制安全边界：在凭据模式到达模型上下文之前将其清除。
-    凭据绝不能出现在沙箱中。
+    Enforce security boundary: scrub credential patterns before they reach model context.
+    Credentials never appear in sandbox.
     """
     _blocked = blocked_patterns or [
         "sk-", "Bearer ", "AZURE_", "password=", "secret=",
@@ -80,7 +80,7 @@ def make_security_middleware(blocked_patterns: list[str] | None = None):
         safe = []
         for msg in ctx.messages:
             if any(p in str(msg) for p in _blocked):
-                print(f"[SECURITY] 已从消息上下文中清除凭据模式。")
+                print(f"[SECURITY] Scrubbed credential patterns from message context.")
                 continue
             safe.append(msg)
         ctx.messages = safe
@@ -89,10 +89,10 @@ def make_security_middleware(blocked_patterns: list[str] | None = None):
     return _mw
 
 
-# ── 3. 限流 ──────────────────────────────────────────────────────────────
+# ── 3. Rate Limiting ────────────────────────────────────────────────────────────
 
 def make_rate_limit_middleware(max_rpm: int = 60):
-    """简单的滑动窗口限流器。"""
+    """Simple sliding window rate limiter."""
     from collections import deque
 
     window: deque[float] = deque()
@@ -112,10 +112,10 @@ def make_rate_limit_middleware(max_rpm: int = 60):
     return _mw
 
 
-# ── 4. 可观测性（TTFT 指标）──────────────────────────────────────────────
+# ── 4. Observability (TTFT Metrics) ───────────────────────────────────────────
 
 class Metrics:
-    """进程内指标 — 生产环境替换为 OpenTelemetry。"""
+    """In-process metrics — replace with OpenTelemetry in production."""
 
     def __init__(self) -> None:
         self.samples:      list[float] = []

--- a/09.Cases/maf_harness_managed_agent/maf_harness/orchestration/multi_agent.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/orchestration/multi_agent.py
@@ -1,14 +1,14 @@
 """
 maf_harness.orchestration.multi_agent
 ======================================
-实现 Anthropic 的"多大脑、多双手"模式。
+Implements Anthropic's "many brains, many hands" pattern.
 
-  - 专家代理：ResearchAgent、CodeAgent、SummariseAgent
-  - OrchestratorAgent 将任务委派给专家并聚合结果
-  - 通过 AF WorkflowBuilder 实现基于图的路由
-  - run_many_brains()：N 个无状态 Foundry 编排器并行运行
+  - Specialist agents: ResearchAgent, CodeAgent, SummariseAgent
+  - OrchestratorAgent delegates tasks to specialists and aggregates results
+  - Graph-based routing via AF WorkflowBuilder
+  - run_many_brains(): N stateless Foundry harnesses run in parallel
 
-所有 LLM 调用使用 FoundryChatClient — 无 OpenAI 依赖。
+All LLM calls use FoundryChatClient — zero OpenAI dependency.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ from maf_harness.sandbox.sandbox import SandboxManager, SandboxResources
 from maf_harness.session.session_log import EventKind, SessionEvent, SessionLog
 
 
-# ── 共享客户端工厂 ─────────────────────────────────────────────────────────
+# ── Shared Client Factory ───────────────────────────────────────────────────
 
 def _client() -> FoundryChatClient:
     return make_foundry_client()
@@ -49,15 +49,15 @@ def _agent(name: str, instructions: str, tools: list | None = None) -> Agent:
         )
 
 
-# ── 专家代理 ─────────────────────────────────────────────────────────────
+# ── Specialist Agents ──────────────────────────────────────────────────────
 
 def make_research_agent(sandbox_mgr: SandboxManager) -> Agent:
-    """研究大脑 — 仅使用 web_search 沙箱工具。"""
+    """Research brain — uses only web_search sandbox tool."""
 
     async def web_search(
-        query: Annotated[str, Field(description="搜索查询")],
+        query: Annotated[str, Field(description="Search query")],
     ) -> str:
-        """在网上搜索信息。"""
+        """Search the web for information."""
         sid = await sandbox_mgr.provision(SandboxResources(allowed_tools=["web_search"]))
         result = await sandbox_mgr.execute(sid, "web_search", query)
         sandbox_mgr.reclaim(sid)
@@ -75,12 +75,12 @@ def make_research_agent(sandbox_mgr: SandboxManager) -> Agent:
 
 
 def make_code_agent(sandbox_mgr: SandboxManager) -> Agent:
-    """代码大脑 — 仅使用 run_python 沙箱工具。"""
+    """Code brain — uses only run_python sandbox tool."""
 
     async def run_python(
-        code: Annotated[str, Field(description="要执行的 Python 代码")],
+        code: Annotated[str, Field(description="Python code to execute")],
     ) -> str:
-        """执行 Python 代码并返回输出。"""
+        """Execute Python code and return output."""
         sid = await sandbox_mgr.provision(SandboxResources(allowed_tools=["run_python"]))
         result = await sandbox_mgr.execute(sid, "run_python", code)
         sandbox_mgr.reclaim(sid)
@@ -98,7 +98,7 @@ def make_code_agent(sandbox_mgr: SandboxManager) -> Agent:
 
 
 def make_summarise_agent() -> Agent:
-    """总结大脑 — 纯推理，不需要沙箱。"""
+    """Summarisation brain — pure reasoning, no sandbox needed."""
     return _agent(
         name="SummariseAgent",
         instructions=(
@@ -115,26 +115,26 @@ def make_orchestrator_agent(
     summarise_agent: Agent,
 ) -> Agent:
     """
-    编排器大脑。
-    实现"大脑可以将双手传递给彼此"。
+    Orchestrator brain.
+    Implements "brains can pass hands to each other".
     """
 
     async def delegate_research(
-        task: Annotated[str, Field(description="要委派的研究任务")],
+        task: Annotated[str, Field(description="Research task to delegate")],
     ) -> str:
-        """将研究任务委派给 ResearchAgent。"""
+        """Delegate research task to ResearchAgent."""
         return await research_agent.run(task)
 
     async def delegate_code(
-        task: Annotated[str, Field(description="要委派的编码任务")],
+        task: Annotated[str, Field(description="Coding task to delegate")],
     ) -> str:
-        """将编码任务委派给 CodeAgent。"""
+        """Delegate coding task to CodeAgent."""
         return await code_agent.run(task)
 
     async def delegate_summarise(
-        text: Annotated[str, Field(description="要总结的文本")],
+        text: Annotated[str, Field(description="Text to summarise")],
     ) -> str:
-        """将总结任务委派给 SummariseAgent。"""
+        """Delegate summarisation task to SummariseAgent."""
         return await summarise_agent.run(f"Summarise:\n\n{text}")
 
     return _agent(
@@ -151,7 +151,7 @@ def make_orchestrator_agent(
     )
 
 
-# ── 基于图的工作流（AF WorkflowBuilder）─────────────────────────────────────
+# ── Graph-based Workflow (AF WorkflowBuilder) ──────────────────────────────
 
 def build_multi_agent_workflow(
     session_log: SessionLog,
@@ -159,13 +159,13 @@ def build_multi_agent_workflow(
     sandbox_mgr: SandboxManager,
 ):
     """
-    构建 AF 工作流图：
+    Build AF workflow graph:
 
         [classify] → research   ─┐
                    → code        ├→ summarise → END
                    → orchestrate ─┘
 
-    InMemoryCheckpointStorage 在编排器重启后保留工作流状态。
+    InMemoryCheckpointStorage preserves workflow state across harness restarts.
     """
     research_agent  = make_research_agent(sandbox_mgr)
     code_agent      = make_code_agent(sandbox_mgr)
@@ -173,7 +173,7 @@ def build_multi_agent_workflow(
     orchestrator    = make_orchestrator_agent(research_agent, code_agent, summarise_agent)
 
     async def classify_task(task: str) -> dict:
-        """将任务路由到适当的专家代理。"""
+        """Route task to appropriate specialist agent."""
         t = task.lower()
         if any(k in t for k in ["code", "calculate", "compute", "script", "python"]):
             agent_type = "code"
@@ -218,7 +218,7 @@ def build_multi_agent_workflow(
     return builder.build()
 
 
-# ── 多大脑并行启动器 ─────────────────────────────────────────────────────────
+# ── Many Brains Parallel Launcher ─────────────────────────────────────────
 
 async def run_many_brains(
     tasks:       list[str],
@@ -226,14 +226,14 @@ async def run_many_brains(
     sandbox_mgr: SandboxManager,
 ) -> list[dict]:
     """
-    为每个任务生成一个无状态的 Foundry 编排器，并发运行。
+    Spawn a stateless Foundry harness for each task and run them concurrently.
 
-    每个编排器：
-      - 拥有自己的 session_id 和事件日志条目
-      - 仅在实际执行工具时才创建沙箱
-      - 任务完成后丢弃（无状态 / 可替换）
+    Each harness:
+      - Has its own session_id and event log entries
+      - Creates sandbox only when actually executing tools
+      - Is discarded after task completion (stateless / cattle)
 
-    这重现了 Anthropic 在并行工作负载中改善 p50 TTFT 的效果。
+    This reproduces Anthropic's p50 TTFT improvement on parallel workloads.
     """
     from maf_harness.harness.harness import AgentHarness, HarnessConfig
 

--- a/09.Cases/maf_harness_managed_agent/maf_harness/sandbox/sandbox.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/sandbox/sandbox.py
@@ -1,16 +1,16 @@
 """
 maf_harness.sandbox.sandbox
 ============================
-沙箱是"双手" — 一个隔离的执行环境，编排器通过单一接口调用：
+Sandbox is the "hands" — an isolated execution environment that the harness calls via a single interface:
 
     execute(name, input) → string
     provision(resources) → sandbox_id
 
-来自 Anthropic 文章的关键设计决策：
-  - 沙箱是"可替换的"：如果一个挂了，编排器会创建一个新的。
-  - 凭据永远不进入沙箱；它们保存在 VaultStore 中。
-  - 沙箱按需创建（而非预先创建） — 这使 Anthropic 的
-    p50 TTFT 减少了约 60%，p95 减少了超过 90%。
+Key design decisions from the Anthropic article:
+  - Sandboxes are "cattle": if one dies, the harness creates a new one.
+  - Credentials never enter the sandbox; they are kept in VaultStore.
+  - Sandboxes are created on-demand (not pre-provisioned) — this reduced Anthropic's
+    p50 TTFT by ~60% and p95 by >90%.
 """
 
 from __future__ import annotations
@@ -22,12 +22,12 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 
 
-# ── 凭据保险库 ──────────────────────────────────────────────────────────────
+# ── Credential Vault ────────────────────────────────────────────────────────
 
 class VaultStore:
     """
-    安全凭据存储 — 令牌永远不进入沙箱。
-    生产环境中使用 Azure Key Vault 作为后端。
+    Secure credential storage — tokens never enter the sandbox.
+    Use Azure Key Vault as backend in production.
     """
 
     def __init__(self) -> None:
@@ -43,7 +43,7 @@ class VaultStore:
         self._vault.pop(key, None)
 
 
-# ── 沙箱资源规格 ─────────────────────────────────────────────────────────────
+# ── Sandbox Resource Spec ─────────────────────────────────────────────────────────
 
 @dataclass
 class SandboxResources:
@@ -54,10 +54,10 @@ class SandboxResources:
     allowed_tools: list[str]  = field(default_factory=list)
 
 
-# ── 工具注册表 ─────────────────────────────────────────────────────────────
+# ── Tool Registry ───────────────────────────────────────────────────────────
 
 class ToolRegistry:
-    """沙箱内可用的命名可调用工具的注册表。"""
+    """Registry of named callable tools available within the sandbox."""
 
     def __init__(self) -> None:
         self._tools: dict[str, Callable] = {}
@@ -72,12 +72,12 @@ class ToolRegistry:
         return list(self._tools.keys())
 
 
-# ── 沙箱实例 ──────────────────────────────────────────────────────────────
+# ── Sandbox Instance ────────────────────────────────────────────────────────
 
 class Sandbox:
     """
-    单个沙箱实例。除活跃标志外无状态。
-    标准接口：await sandbox.execute(name, input) → str
+    A single sandbox instance. Stateless except for alive flag.
+    Standard interface: await sandbox.execute(name, input) → str
     """
 
     def __init__(

--- a/09.Cases/maf_harness_managed_agent/maf_harness/sandbox/sandbox.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/sandbox/sandbox.py
@@ -100,8 +100,8 @@ class Sandbox:
 
     async def execute(self, name: str, input_data: str) -> str:
         """
-        execute(name, input) → string — 大脑↔双手的唯一接口。
-        编排器不关心 'name' 映射到容器、子进程还是其他执行后端。
+        execute(name, input) → string — the sole interface between brain ↔ hands.
+        The orchestrator doesn't care whether 'name' maps to a container, subprocess, or other execution backend.
         """
         if not self._alive:
             raise RuntimeError(f"Sandbox {self.sandbox_id} is dead.")
@@ -132,19 +132,19 @@ class Sandbox:
             return f"[TOOL ERROR] {name}: {exc}"
 
     def kill(self) -> None:
-        """将沙箱标记为已终止 — 编排器将创建一个替代品。"""
+        """Mark the sandbox as terminated — the orchestrator will create a replacement."""
         self._alive = False
 
 
-# ── 沙箱管理器 ───────────────────────────────────────────────────────────────
+# ── Sandbox Manager ───────────────────────────────────────────────────────────────
 
 class SandboxManager:
     """
-    创建和跟踪沙箱实例。
+    Creates and tracks sandbox instances.
 
-    对应 Anthropic 的 provision({resources}) → sandbox_id 模式。
-    沙箱仅在编排器实际需要执行时才创建；
-    纯推理的会话永远不会承担创建开销。
+    Corresponds to Anthropic's provision({resources}) → sandbox_id pattern.
+    Sandboxes are created only when the orchestrator actually needs execution;
+    purely inferential sessions never incur creation overhead.
     """
 
     def __init__(self, vault: VaultStore) -> None:
@@ -153,12 +153,12 @@ class SandboxManager:
         self._sandboxes: dict[str, Sandbox] = {}
         self._register_builtin_tools()
 
-    # ── 内置工具注册 ────────────────────────────────────────────────────────
+    # ── Built-in Tool Registration ────────────────────────────────────────────
 
     def _register_builtin_tools(self) -> None:
 
         async def run_python(code: str, **_) -> str:
-            """在隔离的子进程中执行 Python 代码片段。"""
+            """Execute Python code snippet in an isolated subprocess."""
             try:
                 proc = await asyncio.create_subprocess_exec(
                     "python3", "-c", code,
@@ -173,7 +173,7 @@ class SandboxManager:
                 return f"[EXEC ERROR] {e}"
 
         async def web_search(query: str, **_) -> str:
-            """模拟网络搜索（生产环境替换为 Bing / Azure AI Search）。"""
+            """Mock web search (replace with Bing / Azure AI Search in production)."""
             return (
                 f"[SEARCH: '{query}']\n"
                 f"1. Result A — overview of '{query}'\n"
@@ -189,7 +189,7 @@ class SandboxManager:
                 return f"[FILE ERROR] {e}"
 
         async def write_file(payload: str, **_) -> str:
-            """负载格式: 'path::content'"""
+            """Payload format: 'path::content'"""
             if "::" not in payload:
                 return "[FILE ERROR] payload must be 'path::content'"
             path, content = payload.split("::", 1)
@@ -206,15 +206,15 @@ class SandboxManager:
         self._registry.register("write_file", write_file)
 
     def register_tool(self, name: str, fn: Callable) -> None:
-        """在运行时注册自定义工具。"""
+        """Register custom tools at runtime."""
         self._registry.register(name, fn)
 
-    # ── 创建 / 执行 / 回收 ─────────────────────────────────────────────────
+    # ── Create / Execute / Reclaim ─────────────────────────────────────────────
 
     async def provision(self, resources: SandboxResources | None = None) -> str:
         """
-        创建新沙箱。等价于 provision({resources})。
-        由编排器延迟调用 — 仅在实际需要工具时才调用。
+        Create a new sandbox. Equivalent to provision({resources}).
+        Called lazily by the orchestrator — only when tools are actually needed.
         """
         resources  = resources or SandboxResources()
         sandbox_id = str(uuid.uuid4())
@@ -230,7 +230,7 @@ class SandboxManager:
         return self._sandboxes.get(sandbox_id)
 
     async def execute(self, sandbox_id: str, name: str, input_data: str) -> str:
-        """将 execute(name, input) → string 路由到指定沙箱。"""
+        """Route execute(name, input) → string to the specified sandbox."""
         sandbox = self.get(sandbox_id)
         if sandbox is None or not sandbox.alive:
             raise RuntimeError(
@@ -239,7 +239,7 @@ class SandboxManager:
         return await sandbox.execute(name, input_data)
 
     def reclaim(self, sandbox_id: str) -> None:
-        """终止并丢弃沙箱（可替换模式）。"""
+        """Terminate and discard sandbox (replaceable pattern)."""
         if sandbox_id in self._sandboxes:
             self._sandboxes[sandbox_id].kill()
             del self._sandboxes[sandbox_id]

--- a/09.Cases/maf_harness_managed_agent/maf_harness/session/session_log.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/session/session_log.py
@@ -1,17 +1,17 @@
 """
 maf_harness.session.session_log
 ================================
-持久化、仅追加事件日志 — Anthropic 托管代理架构中的"会话"层。
+Durable, append-only event log — the "Session" layer in Anthropic's Managed Agent architecture.
 
-关键接口（对应 Anthropic 文章）：
+Key interfaces (mapping to Anthropic article):
     create_session(task)            → session_id
-    emit_event(session_id, event)   → 追加到日志
-    get_events(session_id, ...)     → 位置/过滤切片
-    get_session(session_id)         → AF AgentSession 元数据
-    wake(session_id)                → (session, all_events) 用于编排器恢复
-    get_context_window(session_id)  → 最近 N 条事件，用于上下文工程
+    emit_event(session_id, event)   → append to log
+    get_events(session_id, ...)     → positional/filtered slicing
+    get_session(session_id)         → AF AgentSession metadata
+    wake(session_id)                → (session, all_events) for harness recovery
+    get_context_window(session_id)  → recent N events for context engineering
 
-底层使用 AF InMemoryHistoryProvider（生产环境替换为 CosmosDB / Redis）。
+Underlying uses AF InMemoryHistoryProvider (replace with CosmosDB / Redis in production).
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from typing import Any
 from agent_framework import AgentSession, InMemoryHistoryProvider, Message, Role
 
 
-# ── 事件模型 ───────────────────────────────────────────────────────────────────
+# ── Event Model ───────────────────────────────────────────────────────────────
 
 class EventKind(str, Enum):
     SESSION_START   = "session_start"
@@ -60,15 +60,15 @@ class SessionEvent:
         }
 
 
-# ── 会话日志 ───────────────────────────────────────────────────────────────────
+# ── Session Log ───────────────────────────────────────────────────────────────
 
 class SessionLog:
     """
-    仅追加、持久化事件存储。
+    Append-only, durable event store.
 
-    会话存在于编排器和沙箱之外。
-    如果编排器崩溃，会话不受影响；新编排器
-    调用 wake(session_id) 从最后一个事件处恢复。
+    Sessions exist outside the harness and sandbox.
+    If the harness crashes, the session is unaffected; a new harness
+    calls wake(session_id) to recover from the last event.
     """
 
     def __init__(self) -> None:
@@ -84,7 +84,7 @@ class SessionLog:
         task:     str,
         metadata: dict[str, Any] | None = None,
     ) -> str:
-        """创建新会话并发出 SESSION_START 事件。"""
+        """Create a new session and emit SESSION_START event."""
         session_id = str(uuid.uuid4())
         af_session = AgentSession(session_id=session_id)
 
@@ -104,7 +104,7 @@ class SessionLog:
         return session_id
 
     async def emit_event(self, session_id: str, event: SessionEvent) -> None:
-        """向日志追加一个事件。等价于 emitEvent(id, event)。"""
+        """Append an event to the log. Equivalent to emitEvent(id, event)."""
         event.session_id = session_id
         async with self._lock:
             self._store.setdefault(session_id, []).append(event)
@@ -117,8 +117,8 @@ class SessionLog:
         kind_filter: list[EventKind] | None = None,
     ) -> list[SessionEvent]:
         """
-        返回事件流的位置切片。
-        等价于 getEvents() — "从上次停止的位置继续"。
+        Return positional slice of event stream.
+        Equivalent to getEvents() — "resume from where you left off".
         """
         async with self._lock:
             events = self._store.get(session_id, [])
@@ -128,7 +128,7 @@ class SessionLog:
             return list(sliced)
 
     async def get_session(self, session_id: str) -> AgentSession | None:
-        """检索会话元数据。等价于 getSession(id)。"""
+        """Retrieve session metadata. Equivalent to getSession(id)."""
         return self._sessions.get(session_id)
 
     async def wake(
@@ -136,8 +136,8 @@ class SessionLog:
         session_id: str,
     ) -> tuple[AgentSession | None, list[SessionEvent]]:
         """
-        从持久化会话中重新注入编排器。
-        等价于 wake(sessionId) → (session, event_log)。
+        Rehydrate harness from durable session.
+        Equivalent to wake(sessionId) → (session, event_log).
         """
         session = await self.get_session(session_id)
         events  = await self.get_events(session_id)
@@ -151,19 +151,19 @@ class SessionLog:
         )
         return session, events
 
-    # ── AF 历史记录集成 ────────────────────────────────────────────────────────
+    # ── AF History Integration ────────────────────────────────────────────────────
 
     def get_history_provider(self, session_id: str) -> InMemoryHistoryProvider | None:
         return self._history.get(session_id)
 
-    # ── 上下文工程 ───────────────────────────────────────────────────────────
+    # ── Context Engineering ──────────────────────────────────────────────────────
 
     async def get_context_window(
         self,
         session_id: str,
         last_n:     int = 20,
     ) -> list[SessionEvent]:
-        """最近 N 条事件 — 基于会话日志的轻量级上下文窗口。"""
+        """Recent N events — lightweight context window based on session log."""
         events = await self.get_events(session_id)
         return events[-last_n:]
 

--- a/09.Cases/maf_harness_managed_agent/maf_harness/session/session_log.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/session/session_log.py
@@ -77,7 +77,7 @@ class SessionLog:
         self._history:  dict[str, InMemoryHistoryProvider]    = {}
         self._lock = asyncio.Lock()
 
-    # ── 生命周期 ─────────────────────────────────────────────────────────────
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
 
     async def create_session(
         self,

--- a/09.Cases/maf_harness_managed_agent/maf_harness/skills/skills.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/skills/skills.py
@@ -1,11 +1,11 @@
 """
 maf_harness.skills.skills
 ==========================
-封装为 Microsoft Agent Framework 技能的可复用领域能力。
+Reusable domain capabilities encapsulated as Microsoft Agent Framework Skills.
 
-技能定义了大脑知道如何做什么（指令 + 结构）。
-实际执行通过 sandbox.execute() 完成 — 技能和沙箱
-是正交的关注点。
+Skills define what the brain knows how to do (instructions + structure).
+Actual execution is done via sandbox.execute() — skills and sandbox
+are orthogonal concerns.
 
 AF API: Skill, SkillScript, SkillsProvider
 """
@@ -141,7 +141,7 @@ def make_orchestration_skill() -> Skill:
     )
 
 
-# ── 技能提供者工厂 ───────────────────────────────────────────────────────────
+# ── Skills Provider Factory ───────────────────────────────────────────────────────
 
 _ALL: dict[str, callable] = {
     "research":       make_research_skill,
@@ -153,8 +153,8 @@ _ALL: dict[str, callable] = {
 
 def build_skills_provider(skill_names: list[str] | None = None) -> SkillsProvider:
     """
-    构建包含所请求技能的 AF SkillsProvider。
-    传入 None 表示包含所有技能。
+    Build AF SkillsProvider containing requested skills.
+    Pass None to include all skills.
     """
     names    = skill_names or list(_ALL.keys())
     selected = []

--- a/09.Cases/maf_harness_managed_agent/maf_harness/skills/skills.py
+++ b/09.Cases/maf_harness_managed_agent/maf_harness/skills/skills.py
@@ -22,7 +22,7 @@ def _dedent(text: str) -> str:
     return textwrap.dedent(text).strip()
 
 
-# ── 技能定义 ─────────────────────────────────────────────────────────────
+# ── Skill Definitions ─────────────────────────────────────────────────────────────
 
 def make_research_skill() -> Skill:
     return Skill(

--- a/09.Cases/maf_harness_managed_agent/main.py
+++ b/09.Cases/maf_harness_managed_agent/main.py
@@ -36,7 +36,7 @@ from maf_harness.sandbox.sandbox    import SandboxManager, VaultStore
 from maf_harness.session.session_log import EventKind, SessionLog
 
 
-# ── 共享基础设施 ─────────────────────────────────────────────────────────────
+# ── Shared Infrastructure ──────────────────────────────────────────────────
 
 vault       = VaultStore()
 session_log = SessionLog()
@@ -55,7 +55,7 @@ def _harness(name: str = "ManagedAgent") -> AgentHarness:
     )
 
 
-# ── 辅助函数 ─────────────────────────────────────────────────────────────────
+# ── Helper Functions ───────────────────────────────────────────────────────
 
 def _banner(title: str, subtitle: str = "") -> None:
     print(f"\n{'═' * 68}\n{title}")
@@ -77,11 +77,11 @@ async def _event_breakdown(session_id: str) -> None:
     print(f"[SESSION {session_id[:8]}] events → {kinds}")
 
 
-# ── 演示 1：单轮会话 ─────────────────────────────────────────────────────────
+# ── Demo 1: Single Turn Session ───────────────────────────────────────────
 
 async def demo_single_turn() -> None:
     _banner(
-        "演示 1 — 单轮会话",
+        "Demo 1 — Single Turn Session",
         "create_session → start → run → shutdown",
     )
     task = "What is 6 × 7? Verify by running Python code."
@@ -97,12 +97,12 @@ async def demo_single_turn() -> None:
     await _event_breakdown(sid)
 
 
-# ── 演示 2：多轮对话 ─────────────────────────────────────────────────────────
+# ── Demo 2: Multi-Turn Conversation ───────────────────────────────────────
 
 async def demo_multi_turn() -> None:
     _banner(
-        "演示 2 — 多轮对话",
-        "同一个 session_id 跨多次 run() 调用复用",
+        "Demo 2 — Multi-Turn Conversation",
+        "Reuse the same session_id across multiple run() calls",
     )
     sid = await session_log.create_session("Multi-turn Foundry session")
     print(f"\n[SESSION] {sid[:12]}…")
@@ -123,12 +123,12 @@ async def demo_multi_turn() -> None:
     await _event_breakdown(sid)
 
 
-# ── 演示 3：编排器崩溃 + wake 恢复 ───────────────────────────────────────────
+# ── Demo 3: Harness Crash + Wake Recovery ─────────────────────────────────
 
 async def demo_harness_recovery() -> None:
     _banner(
-        "演示 3 — 编排器崩溃恢复（wake 模式）",
-        "编排器 #1 崩溃 → 编排器 #2 从持久化会话日志中恢复",
+        "Demo 3 — Harness Crash Recovery (wake mode)",
+        "Harness #1 crashes → Harness #2 recovers from durable session log",
     )
     sid = await session_log.create_session("Crash recovery demo")
     print(f"\n[SESSION] {sid[:12]}…")
@@ -137,32 +137,32 @@ async def demo_harness_recovery() -> None:
     await h1.start(sid)
     r1 = await h1.run("List three benefits of async programming in Python.")
     print(f"\n[H1] {_clip(r1, 200)}")
-    print(f"\n[H1] 💥  模拟崩溃 — 编排器未经 shutdown 直接丢弃…")
+    print(f"\n[H1] 💥  Simulating crash — harness discarded without shutdown…")
     del h1
 
     n_before = await session_log.event_count(sid)
-    print(f"[LOG] 崩溃后仍保留 {n_before} 条事件 ✓")
+    print(f"[LOG] {n_before} events still preserved after crash ✓")
 
-    print("\n[H2] wake(session_id) → 从持久化日志恢复…")
+    print("\n[H2] wake(session_id) → recovering from durable log…")
     h2 = _harness("Harness-2")
     await h2.start(sid)       # internally calls SessionLog.wake()
     r2 = await h2.run(
         "Give a short Python async/await example based on what you found."
     )
-    print(f"\n[H2] 无缝继续: {_clip(r2, 280)}")
+    print(f"\n[H2] Seamless continuation: {_clip(r2, 280)}")
     await h2.shutdown()
 
     n_after = await session_log.event_count(sid)
-    print(f"\n[LOG] 最终: {n_after} 条事件（恢复后增加 {n_after - n_before} 条）")
+    print(f"\n[LOG] Final: {n_after} events ({n_after - n_before} added after recovery)")
     await _event_breakdown(sid)
 
 
-# ── 演示 4：流式输出 ─────────────────────────────────────────────────────────
+# ── Demo 4: Streaming Output ──────────────────────────────────────────────
 
 async def demo_streaming() -> None:
     _banner(
-        "演示 4 — 流式响应",
-        "run_streaming() 在 token 从 Foundry 到达时逐步返回",
+        "Demo 4 — Streaming Response",
+        "run_streaming() returns tokens incrementally as they arrive from Foundry",
     )
     sid = await session_log.create_session("Streaming demo")
     h   = _harness("StreamAgent")
@@ -181,12 +181,12 @@ async def demo_streaming() -> None:
     await h.shutdown()
 
 
-# ── 演示 5：多大脑、多双手 ───────────────────────────────────────────────────
+# ── Demo 5: Many Brains, Many Hands ───────────────────────────────────────
 
 async def demo_many_brains() -> None:
     _banner(
-        "演示 5 — 多大脑 × 多双手",
-        "N 个无状态 Foundry 编排器并发运行；沙箱按需创建",
+        "Demo 5 — Many Brains × Many Hands",
+        "N stateless Foundry harnesses run concurrently; sandboxes created on demand",
     )
     tasks = [
         "What is the capital of Japan? One sentence only.",
@@ -194,7 +194,7 @@ async def demo_many_brains() -> None:
         "Give one fun fact about Microsoft Foundry.",
     ]
 
-    print(f"\n[ORCHESTRATOR] 启动 {len(tasks)} 个并行 Foundry 大脑…")
+    print(f"\n[ORCHESTRATOR] Launching {len(tasks)} parallel Foundry brains…")
     results = await run_many_brains(tasks, session_log, sandbox_mgr)
 
     for r in results:
@@ -208,12 +208,12 @@ async def demo_many_brains() -> None:
     print(f"\n[METRICS] {GLOBAL_METRICS.summary()}")
 
 
-# ── 演示 6：会话日志检查 ─────────────────────────────────────────────────────
+# ── Demo 6: Session Log Inspection ────────────────────────────────────────
 
 async def demo_session_log() -> None:
     _banner(
-        "演示 6 — 会话日志检查",
-        "getEvents() 切片用于上下文窗口管理",
+        "Demo 6 — Session Log Inspection",
+        "getEvents() slicing for context window management",
     )
     sid = await session_log.create_session("Log inspection demo")
     h   = _harness()
@@ -223,29 +223,29 @@ async def demo_session_log() -> None:
     await h.shutdown()
 
     all_events = await session_log.get_events(sid)
-    print(f"\n[LOG] 总事件数: {len(all_events)}")
+    print(f"\n[LOG] Total events: {len(all_events)}")
 
     recent = await session_log.get_context_window(sid, last_n=5)
-    print(f"\n[CONTEXT WINDOW] 最近 5 条事件:")
+    print(f"\n[CONTEXT WINDOW] Last 5 events:")
     for e in recent:
         print(f"  [{e.kind.value:22s}] {str(e.payload)[:80]}")
 
     responses = await session_log.get_events(
         sid, kind_filter=[EventKind.AGENT_RESPONSE]
     )
-    print(f"\n[FILTER] 代理响应: {len(responses)} 条")
+    print(f"\n[FILTER] Agent responses: {len(responses)} events")
 
     sliced = await session_log.get_events(sid, start=1, end=4)
     print(f"[SLICE 1:4] {len(sliced)} events: "
           + ", ".join(e.kind.value for e in sliced))
 
 
-# ── 演示 7：安全边界 ─────────────────────────────────────────────────────────
+# ── Demo 7: Security Boundary ─────────────────────────────────────────────
 
 async def demo_security() -> None:
     _banner(
-        "演示 7 — 安全边界",
-        "VaultStore 持有令牌；沙箱永远看不到凭据",
+        "Demo 7 — Security Boundary",
+        "VaultStore holds tokens; sandbox never sees credentials",
     )
     vault.store("foundry_key",   "FoundryKey-XXXX")
     vault.store("github_token",  "ghp_XXXXXXXX")
@@ -260,18 +260,18 @@ async def demo_security() -> None:
         "run_python",
         "import os; print(os.environ.get('FOUNDRY_API_KEY', 'NOT_VISIBLE'))",
     )
-    print(f"\n[SANDBOX] 从沙箱内部读取 FOUNDRY_API_KEY: {r1!r}  ✓")
+    print(f"\n[SANDBOX] Reading FOUNDRY_API_KEY from inside sandbox: {r1!r}  ✓")
 
-    r2 = await box.execute("shell", "cat /etc/secrets")  # 被阻止的工具
-    print(f"[SANDBOX] 被阻止的工具 'shell': {r2!r}  ✓")
+    r2 = await box.execute("shell", "cat /etc/secrets")  # Blocked tool
+    print(f"[SANDBOX] Blocked tool 'shell': {r2!r}  ✓")
 
     box.kill()
     sid2 = await sandbox_mgr.provision()
-    print(f"\n[SANDBOX] 旧沙箱已销毁（可替换模式）。新沙箱: {sid2[:12]}…  ✓")
+    print(f"\n[SANDBOX] Old sandbox destroyed (cattle mode). New sandbox: {sid2[:12]}…  ✓")
     sandbox_mgr.reclaim(sid2)
 
 
-# ── 入口 ─────────────────────────────────────────────────────────────────────
+# ── Entry Point ────────────────────────────────────────────────────────────
 
 DEMOS = {
     "single":   demo_single_turn,


### PR DESCRIPTION
This pull request translates all user-facing documentation, comments, and docstrings from Chinese to clear, idiomatic English across the core harness, hosting, and middleware modules. The code logic remains unchanged, but all developer documentation is now accessible to an English-speaking audience, improving maintainability and onboarding for non-Chinese readers.

**Harness Module Documentation and Comments**  
* All docstrings, inline comments, and section headers in `harness.py` are now in English, covering the overall harness design, configuration, sandbox tool wrappers, and agent lifecycle. [[1]](diffhunk://#diff-4818e9ee9623ad52d223a162df277e1644a8613e46391f6262fff3a5a3aa9ad4L4-R19) [[2]](diffhunk://#diff-4818e9ee9623ad52d223a162df277e1644a8613e46391f6262fff3a5a3aa9ad4L51-R61) [[3]](diffhunk://#diff-4818e9ee9623ad52d223a162df277e1644a8613e46391f6262fff3a5a3aa9ad4L83-R91) [[4]](diffhunk://#diff-4818e9ee9623ad52d223a162df277e1644a8613e46391f6262fff3a5a3aa9ad4L100-R110) [[5]](diffhunk://#diff-4818e9ee9623ad52d223a162df277e1644a8613e46391f6262fff3a5a3aa9ad4L152-R202) [[6]](diffhunk://#diff-4818e9ee9623ad52d223a162df277e1644a8613e46391f6262fff3a5a3aa9ad4L215-R225) [[7]](diffhunk://#diff-4818e9ee9623ad52d223a162df277e1644a8613e46391f6262fff3a5a3aa9ad4L281-R284) [[8]](diffhunk://#diff-4818e9ee9623ad52d223a162df277e1644a8613e46391f6262fff3a5a3aa9ad4L310-R318)

**Hosting (Azure Functions/FastAPI) Documentation**  
* All endpoint documentation, comments, and usage instructions in `azure_function_host.py` are translated to English, including explanations about stateless session routing and local development with FastAPI. [[1]](diffhunk://#diff-ef2867f74c34a3718f39215e6221e88c5aae02481410d7bbbc777ea77035e049L4-R15) [[2]](diffhunk://#diff-ef2867f74c34a3718f39215e6221e88c5aae02481410d7bbbc777ea77035e049L27-R27) [[3]](diffhunk://#diff-ef2867f74c34a3718f39215e6221e88c5aae02481410d7bbbc777ea77035e049L50-R50) [[4]](diffhunk://#diff-ef2867f74c34a3718f39215e6221e88c5aae02481410d7bbbc777ea77035e049L62-R63) [[5]](diffhunk://#diff-ef2867f74c34a3718f39215e6221e88c5aae02481410d7bbbc777ea77035e049L74-R74) [[6]](diffhunk://#diff-ef2867f74c34a3718f39215e6221e88c5aae02481410d7bbbc777ea77035e049L88-R88) [[7]](diffhunk://#diff-ef2867f74c34a3718f39215e6221e88c5aae02481410d7bbbc777ea77035e049L129-R129) [[8]](diffhunk://#diff-ef2867f74c34a3718f39215e6221e88c5aae02481410d7bbbc777ea77035e049L174-R183)

**Middleware Documentation and Comments**  
* All middleware stack descriptions, section headers, and docstrings in `middleware.py` are now in English, detailing session logging, security, rate limiting, and observability. [[1]](diffhunk://#diff-baab9ab4b3e962301723158ad93837ae1ea4f2457edee08d1ddd012d24620e0fL4-R11) [[2]](diffhunk://#diff-baab9ab4b3e962301723158ad93837ae1ea4f2457edee08d1ddd012d24620e0fL27-R30) [[3]](diffhunk://#diff-baab9ab4b3e962301723158ad93837ae1ea4f2457edee08d1ddd012d24620e0fL66-R71) [[4]](diffhunk://#diff-baab9ab4b3e962301723158ad93837ae1ea4f2457edee08d1ddd012d24620e0fL83-R83) [[5]](diffhunk://#diff-baab9ab4b3e962301723158ad93837ae1ea4f2457edee08d1ddd012d24620e0fL92-R95) [[6]](diffhunk://#diff-baab9ab4b3e962301723158ad93837ae1ea4f2457edee08d1ddd012d24620e0fL115-R118) [[7]](diffhunk://#diff-baab9ab4b3e962301723158ad93837ae1ea4f2457edee08d1ddd012d24620e0fL158-R160)