### PR TITLE
Fix URL in main branch

### DIFF
--- a/09.Cases/README.md
+++ b/09.Cases/README.md
@@ -2,17 +2,17 @@
 
 Each subfolder in this directory showcases a different production-ready scenario that applies Microsoft Agent Framework and Microsoft Foundry tooling to real-world workflows. The projects mix multi-agent orchestration, web/UI integrations, and observability so you can see how agents behave across marketing, travel guidance, and enterprise process automation contexts.
 
-## [AgenticMarketingContentGen](09.Cases/AgenticMarketingContentGen/README.md)
+## [AgenticMarketingContentGen](./AgenticMarketingContentGen/README.md)
 This workspace automates marketing campaigns with a modular, four-phased agent workflow (strategy, copywriting, images, video). You describe a product or topic, and the system runs a strategy agent, optional deep research, and content agents that produce publish-ready text plus image/video assets, all packaged through the `CampaignPackage` model and persisted under `artifacts/campaigns`. CLI flags toggle deep research, image generation, video generation, and verbose debugging to adapt to different stages of a campaign run.
 
-## [GHModel.AI](09.Cases/GHModel.AI/README.md)
+## [GHModel.AI](./GHModel.AI/README.md)
 GHModel.AI bundles Python and .NET samples that demonstrate AG-UI, DevUI, and OpenTelemetry integrations for a travel assistant scenario. The dual-agent workflow (FrontDesk + Concierge) runs inside the Microsoft Agent Framework while AG-UI provides streaming SSE, DevUI enables visual local debugging, and OpenTelemetry (with the Aspire Dashboard or Application Insights) captures traces, metrics, and logs. Each sample shows how to register agents, wire up DevUI/AG-UI endpoints, and monitor production telemetry, giving a hands-on path from local testing to observability.
 
-## [FoundryLocalPipeline](09.Cases/FoundryLocalPipeline/README.md)
+## [FoundryLocalPipeline](./FoundryLocalPipeline/README.md)
 This project demonstrates how to use Microsoft Foundry Local (e.g., Qwen2.5-1.5B) to build a Deep Research workflow with full evaluation, orchestration, and visualization via Microsoft Agent Framework (MAF). Key features include red teaming evaluation for safety and compliance risk checks, an iterative Deep Research workflow with web search tools, interactive debugging with MAF DevUI, and a path toward observability and performance evaluation with .NET Aspire. The scripts cover local SLM inference, multi-strategy attack testing, and loop-based research synthesis with citations.
 
-## [MicrosoftFoundryWithAITKAndMAF](09.Cases/MicrosoftFoundryWithAITKAndMAF/README.md)
+## [MicrosoftFoundryWithAITKAndMAF](./MicrosoftFoundryWithAITKAndMAF/README.md)
 This narrative documents moving from concept to code through Microsoft Foundry and the Agent Framework. It uses a recruitment scenario with Recruiter and Applicant agents to illustrate a three-phase lifecycle: low-code workflow design in Foundry, code synchronization via the VS Code extension, and deployment on the Microsoft Agent Framework runtime using YAML-based “configuration as code.” The subdirectories contain the workflow YAML definitions and guidance for running the generated agents and workflows locally.
 
-## [maf_harness_managed_agent](09.Cases/maf_harness_managed_agent/README.md)
+## [maf_harness_managed_agent](./maf_harness_managed_agent/README.md)
 This project implements Anthropic's managed-agent pattern (“decoupling the brain from the hands”) with Microsoft Agent Framework and Microsoft Foundry. It separates a stateless `AgentHarness` (brain), durable append-only `SessionLog` (memory), and on-demand sandbox execution layer (hands), then demonstrates recovery after harness crashes via `wake(session_id)` and parallel orchestration with many-brains-many-hands workflows. The sample also includes Azure Functions/FastAPI hosting endpoints (`/sessions`, `/run`, `/events`, `/wake`, `/health`) and production-oriented extension points for replacing in-memory components with Azure services such as Cosmos DB, Blob Storage, Key Vault, and Azure Monitor.


### PR DESCRIPTION
This pull request updates the documentation links in the `09.Cases/README.md` file to use relative paths, ensuring that navigation works correctly regardless of where the README is viewed. No other functional or content changes are included.

- Documentation improvements:
  * Updated all project links in `09.Cases/README.md` to use relative paths (e.g., `./AgenticMarketingContentGen/README.md`) for more robust navigation.