### PR TITLE
Refactor resource configuration and clean up unused settings

### DIFF
--- a/09.Cases/maf_harness_managed_hosted_agent/agent.yaml
+++ b/09.Cases/maf_harness_managed_hosted_agent/agent.yaml
@@ -5,8 +5,8 @@ protocols:
   - protocol: responses
     version: 1.0.0
 resources:
-  cpu: ''
-  memory: ''
+  cpu: '1'
+  memory: '2Gi'
 environment_variables:
   - name: PROJECT_ENDPOINT
     value: ${FOUNDRY_PROJECT_ENDPOINT}

--- a/09.Cases/maf_harness_managed_hosted_agent/azure.yaml
+++ b/09.Cases/maf_harness_managed_hosted_agent/azure.yaml
@@ -11,23 +11,6 @@ services:
         language: docker
         docker:
             remoteBuild: true
-        config:
-            container:
-                resources:
-                    cpu: "1"
-                    memory: 2Gi
-                scale:
-                    maxReplicas: 3
-                    minReplicas: 1
-            deployments:
-                - model:
-                    format: OpenAI
-                    name: gpt-5.4
-                    version: "2026-03-05"
-                  name: gpt-5.4
-                  sku:
-                    capacity: 10
-                    name: GlobalStandard
 infra:
     provider: bicep
     path: ./infra


### PR DESCRIPTION
This pull request updates resource allocation settings for the managed hosted agent in the MAF harness project. The most important change is the standardization of CPU and memory resource definitions by moving them from the Azure service configuration to the main agent configuration.

Resource configuration standardization:

* Set explicit `cpu` (`'1'`) and `memory` (`'2Gi'`) values in the `agent.yaml` file, replacing previous empty values.
* Removed redundant container resource and deployment configuration from the Azure service definition in `azure.yaml`, centralizing resource management.