### PR TITLE
Update requirements.txt for orchestration packages and OpenTelemetry

### DIFF
--- a/Installation/requirements.txt
+++ b/Installation/requirements.txt
@@ -9,3 +9,6 @@ agent-framework-github-copilot @ git+https://github.com/microsoft/agent-framewor
 agent-framework-declarative @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/declarative
 agent-framework-foundry-local @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/foundry_local
 agent-framework-orchestrations @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/orchestrations
+agent-framework-hyperlight @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/hyperlight
+agent-framework-monty @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/monty
+agent-framework-tools @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/tools

--- a/Installation/requirements.txt
+++ b/Installation/requirements.txt
@@ -12,3 +12,32 @@ agent-framework-orchestrations @ git+https://github.com/microsoft/agent-framewor
 agent-framework-hyperlight @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/hyperlight
 agent-framework-monty @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/monty
 agent-framework-tools @ git+https://github.com/microsoft/agent-framework.git@main#subdirectory=python/packages/tools
+
+# --- OpenTelemetry stack pins ---
+# microsoft-opentelemetry (pulled in by azure-ai-agentserver-core) and azure-monitor-opentelemetry
+# both strict-pin the OTel stack. Older releases pinned to 1.39 / 0.60b0 / exporter ~=1.0.0b46;
+# the latest releases agree on 1.40 / 0.61b0 / exporter ~=1.0.0b52. Force the newer, consistent set
+# so `pip install -U` does not leave a half-upgraded env with version conflicts.
+microsoft-opentelemetry>=1.3.1
+azure-monitor-opentelemetry>=1.8.8
+azure-monitor-opentelemetry-exporter==1.0.0b52
+opentelemetry-api==1.40.0
+opentelemetry-sdk==1.40.0
+opentelemetry-proto==1.40.0
+opentelemetry-semantic-conventions==0.61b0
+opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-wsgi==0.61b0
+opentelemetry-instrumentation-dbapi==0.61b0
+opentelemetry-instrumentation-django==0.61b0
+opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-flask==0.61b0
+opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-psycopg2==0.61b0
+opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-urllib==0.61b0
+opentelemetry-instrumentation-urllib3==0.61b0


### PR DESCRIPTION
This pull request updates the `requirements.txt` file to add new agent framework packages and to resolve version conflicts in the OpenTelemetry stack by explicitly pinning compatible versions. These changes help ensure consistent dependency management and prevent environment issues during installation.

**Dependency additions:**

* Added `agent-framework-hyperlight`, `agent-framework-monty`, and `agent-framework-tools` as dependencies, referencing their respective subdirectories in the main agent-framework repository.

**OpenTelemetry stack management:**

* Explicitly pinned versions for the OpenTelemetry stack (including `microsoft-opentelemetry`, `azure-monitor-opentelemetry`, and various `opentelemetry-*` packages) to ensure compatibility and prevent version conflicts, especially during upgrades.